### PR TITLE
Feature/fix game bug

### DIFF
--- a/kracker/src/components/RoundsGame.tsx
+++ b/kracker/src/components/RoundsGame.tsx
@@ -572,19 +572,33 @@ const RoundsGame: React.FC = () => {
       setCurrentRound(data.round);
     };
 
+    const onFinal = (data: { round: number; players: PlayerRoundResult[] }) => {
+      console.log(`🏁 최종 결과 라운드 ${data.round}`);
+      setShowRoundModal(false);
+      setIsAugmentSelectModalOpen(false);
+      setIsFinalResultModalOpen(true);
+    };
+
+    const onAugmentProgress = (data: { round: number; selections: Record<string, string>; selectedCount: number; totalPlayers: number }) => {
+      console.log(`📡 증강 진행 상황: ${data.selectedCount}/${data.totalPlayers}`, data.selections);
+    };
+
     const onAugmentComplete = (data: { round: number; selections: Record<string, string> }) => {
       console.log(`🎯 라운드 ${data.round} 증강 선택 완료:`, data.selections);
-      // 증강 선택 완료 후 처리 (예: 다음 라운드 시작)
       setIsAugmentSelectModalOpen(false);
     };
 
     socket.on("round:result", onRoundResult);
     socket.on("round:augment", onRoundAugment);
+    socket.on("game:final", onFinal);
+    socket.on("augment:progress", onAugmentProgress);
     socket.on("augment:complete", onAugmentComplete);
 
     return () => {
       socket.off("round:result", onRoundResult);
       socket.off("round:augment", onRoundAugment);
+      socket.off("game:final", onFinal);
+      socket.off("augment:progress", onAugmentProgress);
       socket.off("augment:complete", onAugmentComplete);
     };
   }, []);
@@ -722,7 +736,13 @@ const RoundsGame: React.FC = () => {
       {/* ★ 최종 결과 모달 */}
       <FinalResultModal
         isOpen={isFinalResultModalOpen}
-        result="WIN"
+        result={undefined}
+        myWins={(() => {
+          const myId = gameState?.myPlayerId;
+          if (!myId) return undefined;
+          const me = roundPlayers.find(p => p.id === myId);
+          return me?.wins;
+        })()}
         onClose={() => setIsFinalResultModalOpen(false)}
       />
     </Container>

--- a/kracker/src/components/modals/AugmentSelectModal.tsx
+++ b/kracker/src/components/modals/AugmentSelectModal.tsx
@@ -84,6 +84,17 @@ const AugmentSelectModal: React.FC<AugmentSelectModalProps> = ({
     }
   }, [chosenBy, players, isOpen, autoCloseWhenAll, onClose]);
 
+  useEffect(() => {
+    const onProgress = (data: { round: number; selections: Record<string, string>; selectedCount: number; totalPlayers: number }) => {
+      // 서버 진행 상황을 로컬 상태에 반영 (다른 플레이어들의 선택 표시)
+      setChosenBy(data.selections || {});
+    };
+    socket.on("augment:progress", onProgress);
+    return () => {
+      socket.off("augment:progress", onProgress);
+    };
+  }, []);
+
   if (!isOpen) return null;
 
   return ReactDOM.createPortal(

--- a/kracker/src/components/modals/FinalResultModal.tsx
+++ b/kracker/src/components/modals/FinalResultModal.tsx
@@ -1,14 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
 import { useNavigate } from "react-router-dom";
 
 export interface FinalResultModalProps {
   isOpen: boolean;
-  result: "WIN" | "LOSE";
+  result?: "WIN" | "LOSE";
   onClose: () => void;
+  // 🆕 최종 결과 판단을 위한 내 승리 스택 전달 (선택)
+  myWins?: number;
 }
 
-const FinalResultModal: React.FC<FinalResultModalProps> = ({ isOpen, result, onClose }) => {
+const FinalResultModal: React.FC<FinalResultModalProps> = ({ isOpen, result, onClose, myWins }) => {
   const [isAnimating, setIsAnimating] = useState(false);
   const navigate = useNavigate();
 
@@ -18,9 +20,15 @@ const FinalResultModal: React.FC<FinalResultModalProps> = ({ isOpen, result, onC
     }
   }, [isOpen]);
 
+  const derivedResult = useMemo<"WIN" | "LOSE">(() => {
+    if (result) return result;
+    if (typeof myWins === "number") return myWins >= 5 ? "WIN" : "LOSE";
+    // 기본값: 패배로 처리
+    return "LOSE";
+  }, [result, myWins]);
+
   const handleClose = () => {
     setIsAnimating(false);
-    // 바로 다른 페이지로 이동 (트랜지션 없이)
     onClose();
     navigate("/", { replace: true });
   };
@@ -35,16 +43,16 @@ const FinalResultModal: React.FC<FinalResultModalProps> = ({ isOpen, result, onC
         inset: 0,
         display: "grid",
         placeItems: "center",
-        background: "linear-gradient(180deg, #000000 0%, #0b0a2c 100%)",
+        background: "rgba(0, 0, 0, 0.85)",
         color: "#fff",
         zIndex: 1200,
         cursor: "pointer",
-        transform: isAnimating ? "translateX(0)" : "translateX(100%)",
-        transition: "transform 300ms cubic-bezier(0.4, 0, 0.2, 1)",
+        opacity: isAnimating ? 1 : 0,
+        transition: "opacity 300ms ease",
       }}
     >
       <div style={{ textAlign: "center" }}>
-        <div style={{ fontSize: 120, fontWeight: 900, letterSpacing: 8 }}>{result}</div>
+        <div style={{ fontSize: 120, fontWeight: 900, letterSpacing: 8 }}>{derivedResult}</div>
         <div style={{ fontSize: 16, opacity: 0.7, marginTop: 16 }}>클릭하여 방에서 나가기</div>
       </div>
     </div>,

--- a/kracker/src/game/managers/UIManager.ts
+++ b/kracker/src/game/managers/UIManager.ts
@@ -181,28 +181,38 @@ export class UIManager {
 
   // 닉네임 태그 생성
   public createNameTag(playerId: string, nickname: string): void {
-    // 기존 태그 있으면 제거
-    const prev = this.nameTags.get(playerId);
-    prev?.destroy();
+    try {
+      // Scene이 준비되지 않은 경우 안전하게 무시
+      const add: any = (this.scene as any)?.add;
+      if (!add || typeof add.text !== "function") {
+        return;
+      }
 
-    const text = this.scene.add
-      .text(0, 0, nickname, {
-        fontFamily: "Apple SD Gothic Neo",
-        fontSize: "14px",
-        color: "#FFFFFF",
-        align: "center",
-        padding: { left: 3, right: 3, top: 1, bottom: 1 },
-      })
-      .setOrigin(0.5, 1) // 중앙 정렬, 아래쪽 기준
-      .setScrollFactor(1) // 월드 좌표 따라다님(카메라 스크롤 반영)
-      .setDepth(this.NAME_TAG_DEPTH);
+      // 기존 태그 있으면 제거
+      const prev = this.nameTags.get(playerId);
+      prev?.destroy();
 
-    // 너무 길면 자동 축소
-    if (text.width > this.NAME_TAG_MAX_WIDTH) {
-      text.setScale(this.NAME_TAG_MAX_WIDTH / text.width);
+      const text = this.scene.add
+        .text(0, 0, nickname, {
+          fontFamily: "Apple SD Gothic Neo",
+          fontSize: "14px",
+          color: "#FFFFFF",
+          align: "center",
+          padding: { left: 3, right: 3, top: 1, bottom: 1 },
+        })
+        .setOrigin(0.5, 1) // 중앙 정렬, 아래쪽 기준
+        .setScrollFactor(1) // 월드 좌표 따라다님(카메라 스크롤 반영)
+        .setDepth(this.NAME_TAG_DEPTH);
+
+      // 너무 길면 자동 축소
+      if (text.width > this.NAME_TAG_MAX_WIDTH) {
+        text.setScale(this.NAME_TAG_MAX_WIDTH / text.width);
+      }
+
+      this.nameTags.set(playerId, text);
+    } catch (e) {
+      // 안전하게 무시
     }
-
-    this.nameTags.set(playerId, text);
   }
 
   // 닉네임 태그 위치 갱신 (hpBarTopY 바로 위에 촘촘히)

--- a/kracker/src/game/player/Player.ts
+++ b/kracker/src/game/player/Player.ts
@@ -701,12 +701,7 @@ export default class Player {
       // 체력이 0이 되었을 때 사망 처리 (서버에서 체력이 0으로 설정된 경우)
       if (this.health <= 0 && oldHealth > 0) {
         console.log(`💀 플레이어 사망 처리`);
-        this.particleSystem.createDeathOxidationParticle(this.x, this.y);
-
-        // 멀티플레이어 파티클 전송
-        if (this.onParticleCreated) {
-          this.onParticleCreated("death", this.x, this.y, this.colors.head);
-        }
+        // 사망 파티클/브로드캐스트는 서버 dead 이벤트에서 처리
       }
     }
   }
@@ -884,6 +879,9 @@ export default class Player {
   public applyBottomBoundaryHit(damageRatio = 0.3, bounceSpeed = 900): void {
     const now = Date.now();
     if (now - this.lastFalloutAt < this.falloutCooldownMs) return; // 중복 방지
+
+    // 사망 상태면 낙사 데미지 무시
+    if (this.health <= 0) return;
 
     const dmg = Math.max(1, Math.round(this.maxHealth * damageRatio));
 

--- a/kracker/src/game/systems/CollisionSystem.ts
+++ b/kracker/src/game/systems/CollisionSystem.ts
@@ -168,54 +168,59 @@ export class CollisionSystem {
 
       // 🔥 총알 ↔ 플레이어 충돌 체크 (원-원)
       if (this.player && typeof this.player.getPosition === "function") {
-        const pos = this.player.getPosition();
-        const pb = this.player.getBounds?.();
-        const playerRadius = pb?.radius ?? 25; // 플레이어 반경(기본값 25)
+        const getHealth = (this.player as any)?.getHealth?.();
+        if (typeof getHealth === "number" && getHealth <= 0) {
+          // 사망 상태면 피격 판정 제외
+        } else {
+          const pos = this.player.getPosition();
+          const pb = this.player.getBounds?.();
+          const playerRadius = pb?.radius ?? 25; // 플레이어 반경(기본값 25)
 
-        const dx = b.x - pos.x;
-        const dy = b.y - pos.y;
-        const bulletR = this.getBulletRadius(b);
-        const rSum = playerRadius + bulletR;
+          const dx = b.x - pos.x;
+          const dy = b.y - pos.y;
+          const bulletR = this.getBulletRadius(b);
+          const rSum = playerRadius + bulletR;
 
-        if (dx * dx + dy * dy <= rSum * rSum) {
-          // 한 프레임 중복 처리 방지
-          b.setData("__hitThisFrame", true);
+          if (dx * dx + dy * dy <= rSum * rSum) {
+            // 한 프레임 중복 처리 방지
+            b.setData("__hitThisFrame", true);
 
-          // 데미지 가져오기
-          const bulletRef = b.getData("__bulletRef");
-          const dmg = bulletRef?.getConfig ? bulletRef.getConfig().damage : 10;
+            // 데미지 가져오기
+            const bulletRef = b.getData("__bulletRef");
+            const dmg = bulletRef?.getConfig ? bulletRef.getConfig().damage : 10;
 
-          // 서버에만 체력 업데이트 전송 (로컬 데미지 처리 제거)
-          if (this.networkManager && this.player) {
-            const playerId = this.player.getId?.() || this.player.id;
-            const hitData = {
-              bulletId: `collision_${Date.now()}`,
-              targetPlayerId: playerId,
-              damage: dmg,
-              x: b.x,
-              y: b.y,
-            };
+            // 서버에만 체력 업데이트 전송 (로컬 데미지 처리 제거)
+            if (this.networkManager && this.player) {
+              const playerId = this.player.getId?.() || this.player.id;
+              const hitData = {
+                bulletId: `collision_${Date.now()}`,
+                targetPlayerId: playerId,
+                damage: dmg,
+                x: b.x,
+                y: b.y,
+              };
 
-            console.log(
-              `💥 CollisionSystem: 서버에 체력 업데이트 전송 - 플레이어: ${playerId}, 데미지: ${dmg}`
-            );
-            this.networkManager.sendBulletHit(hitData);
-          } else {
-            console.warn(
-              `⚠️ CollisionSystem: 네트워크 매니저 또는 플레이어가 없음`
-            );
+              console.log(
+                `💥 CollisionSystem: 서버에 체력 업데이트 전송 - 플레이어: ${playerId}, 데미지: ${dmg}`
+              );
+              this.networkManager.sendBulletHit(hitData);
+            } else {
+              console.warn(
+                `⚠️ CollisionSystem: 네트워크 매니저 또는 플레이어가 없음`
+              );
+            }
+
+            // 총알 폭발/제거
+            try {
+              if (bulletRef?.hit) bulletRef.hit(b.x, b.y);
+              else b.destroy(true);
+            } catch (e) {
+              b.destroy(true);
+            }
+
+            // 이 총알은 처리 완료 → 다음 총알로
+            continue;
           }
-
-          // 총알 폭발/제거
-          try {
-            if (bulletRef?.hit) bulletRef.hit(b.x, b.y);
-            else b.destroy(true);
-          } catch (e) {
-            b.destroy(true);
-          }
-
-          // 이 총알은 처리 완료 → 다음 총알로
-          continue;
         }
       }
 


### PR DESCRIPTION
라운드 종료 후 화면을 3초 정도 잡은 후(즉, 3초 대기) 라운드 종료 방송 - 완
증강 선택 상황 변동시 서버 방송 및 수신
아직 모든 플레이어가 증강을 고르지 않았는데도 서버로 증강 선택 완료 방송이 감
각자 증강 선택 완료를 서버로 보내고 증강 선택 완료 신호가 서버로 올때마다 클라이언트로 그 진행상황을 다시 보내서 실시간으로 상황 연동(기존 코드 있으면 활용) 후 게임 방의 모든 플레이어의 증강 선택을 서버에서 확인하면 3초후 증강 선택 완료 방송을 보냄- 완-
라운드 결과에서 조건을 걸어서 한명 혹은 한 팀이 5라운드 승리 스택이 쌓였다면 증강 선택 모달이 아니라 바로 최종 모달이 나오도록 최종 결과 방송 후 최종 결과 모달 표시 -완-
죽었을 때 관전 - 다른 상대한테 닉네임, 몸, 팔다리,총 다 보임 이거 수정  -완-
매 라운드 시작 시 각 플레이어마다 시작 위치 설정 및 스폰 위치로 이동

+ 죽은 플레이어 몸통,총,팔,다리가 여전히 상대 클라이언트에서 나타나기 때문에 상대 플레이어 캐릭터의 사망 방송이 서버를 통해 클라이언트로 전달되면 해당 플레이어 캐릭터를 확인해서 해당하는 캐릭터의 몸통,총,팔,다리를 숨기고 모든 데미지(낙사 데미지(맵 바닥 경계에 닿았을 때 데미지)도 포함)를 더이상 입지 않음 + hp 감소 안함 - 완-

플레이어의 체력이 0인 상태에서 피해를 입었을 때 체력이 다시 100%로 회복하는 로직이 있을 텐데 그 로직은 비활성화 혹은 제거해야 함 -완 -